### PR TITLE
Fix: Missing init value on Separator

### DIFF
--- a/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
+++ b/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
@@ -71,7 +71,7 @@ export default function TurtlForm() {
                 setDataPrefixUri(dataPrefixUriStr.replace("<","").replace(">",""));
                 //Set Prediate prefix to its default value
                 let predicatePrefixStr = res.data.predicatePrefix
-                setPredicatePrefix(predicatePrefixStr.charAt(0));
+                setPredicatePrefix(predicatePrefixStr.replace(":",""));
                 //Set Predicate Uri to its default value
                 let predicatePrefixUriStr = res.data.predicatePrefixUri
                 setPredicatePrefixUri(predicatePrefixUriStr.replace("<","").replace(">",""));

--- a/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
+++ b/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
@@ -68,13 +68,15 @@ export default function TurtlForm() {
                 setDataPrefix(dataPrefixStr.charAt(0));
                 //Set Data prefix Uri to its default value
                 let dataPrefixUriStr = res.data.dataPrefixUri;
-                setDataPrefixUri(dataPrefixUriStr.substring(1).slice(0,-1));
+                setDataPrefixUri(dataPrefixUriStr.substring(1).slice(0, -1));
                 //Set Prediate prefix to its default value
                 let predicatePrefixStr = res.data.predicatePrefix
                 setPredicatePrefix(predicatePrefixStr.charAt(0));
                 //Set Predicate Uri to its default value
                 let predicatePrefixUriStr = res.data.predicatePrefixUri
-                setPredicatePrefixUri(predicatePrefixUriStr.substring(1).slice(0,-1));
+                setPredicatePrefixUri(predicatePrefixUriStr.substring(1).slice(0, -1));
+                //Set Separator to its default value
+                setSeparator(res.data.separator);
             });
     }, [])
 

--- a/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
+++ b/turtl-front/turtl-front/src/app/pages/TurtlForm/TurtlForm.jsx
@@ -65,16 +65,16 @@ export default function TurtlForm() {
                 setLastLineToProcess(lastLineToProcessStr ? lastLineToProcessStr : '');//Validate if there is a value. if not use '' value
                 //Set Data prefix name to its default value
                 let dataPrefixStr = res.data.dataPrefix;
-                setDataPrefix(dataPrefixStr.charAt(0));
+                setDataPrefix(dataPrefixStr.replace(":",""));
                 //Set Data prefix Uri to its default value
                 let dataPrefixUriStr = res.data.dataPrefixUri;
-                setDataPrefixUri(dataPrefixUriStr.substring(1).slice(0, -1));
+                setDataPrefixUri(dataPrefixUriStr.replace("<","").replace(">",""));
                 //Set Prediate prefix to its default value
                 let predicatePrefixStr = res.data.predicatePrefix
                 setPredicatePrefix(predicatePrefixStr.charAt(0));
                 //Set Predicate Uri to its default value
                 let predicatePrefixUriStr = res.data.predicatePrefixUri
-                setPredicatePrefixUri(predicatePrefixUriStr.substring(1).slice(0, -1));
+                setPredicatePrefixUri(predicatePrefixUriStr.replace("<","").replace(">",""));
                 //Set Separator to its default value
                 setSeparator(res.data.separator);
             });


### PR DESCRIPTION
Added default value on the separator from the init file. 